### PR TITLE
Support io.WriterTo interface

### DIFF
--- a/gunzip.go
+++ b/gunzip.go
@@ -143,6 +143,14 @@ func NewReaderN(r io.Reader, blockSize, blocks int) (*Reader, error) {
 	z.r = makeReader(r)
 	z.digest = crc32.NewIEEE()
 	z.multistream = true
+
+	// Account for too small values
+	if z.blocks <= 0 {
+		z.blocks = defaultBlocks
+	}
+	if z.blockSize <= 512 {
+		z.blockSize = defaultBlockSize
+	}
 	z.blockPool = make(chan []byte, z.blocks)
 	for i := 0; i < z.blocks; i++ {
 		z.blockPool <- make([]byte, z.blockSize)

--- a/gunzip_test.go
+++ b/gunzip_test.go
@@ -6,12 +6,16 @@ package pgzip
 
 import (
 	"bytes"
+	oldgz "compress/gzip"
+	"crypto/rand"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	kpgzip "github.com/klauspost/compress/gzip"
 )
 
 type gunzipTest struct {
@@ -406,5 +410,189 @@ Found:
 
 	if err := r.Reset(br); err != io.EOF {
 		t.Fatalf("third reset: err=%v, want io.EOF", err)
+	}
+}
+
+func TestWriteTo(t *testing.T) {
+	input := make([]byte, 100000)
+	n, err := rand.Read(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(input) {
+		t.Fatal("did not fill buffer")
+	}
+	compressed := &bytes.Buffer{}
+	// Do it twice to test MultiStream functionality
+	for i := 0; i < 2; i++ {
+		w, err := NewWriterLevel(compressed, -2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n, err = w.Write(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != len(input) {
+			t.Fatal("did not fill buffer")
+		}
+		w.Close()
+	}
+	input = append(input, input...)
+	buf := compressed.Bytes()
+
+	dec, err := NewReader(bytes.NewBuffer(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ReadAll does not use WriteTo, but we wrap it in a NopCloser to be sure.
+	readall, err := ioutil.ReadAll(ioutil.NopCloser(dec))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(readall) != len(input) {
+		t.Fatal("did not decompress everything")
+	}
+	if bytes.Compare(readall, input) != 0 {
+		t.Fatal("output did not match input")
+	}
+
+	dec, err = NewReader(bytes.NewBuffer(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtbuf := &bytes.Buffer{}
+	written, err := dec.WriteTo(wtbuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != int64(len(input)) {
+		t.Error("Returned length did not match, expected", len(input), "got", written)
+	}
+	if wtbuf.Len() != len(input) {
+		t.Error("Actual Length did not match, expected", len(input), "got", wtbuf.Len())
+	}
+	if bytes.Compare(wtbuf.Bytes(), input) != 0 {
+		t.Fatal("output did not match input")
+	}
+}
+
+func BenchmarkGunzipCopy(b *testing.B) {
+	dat, _ := ioutil.ReadFile("testdata/test.json")
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dst := &bytes.Buffer{}
+	w, _ := NewWriterLevel(dst, 1)
+	_, err := w.Write(dat)
+	if err != nil {
+		b.Fatal(err)
+	}
+	w.Close()
+	input := dst.Bytes()
+	r, err := NewReader(bytes.NewBuffer(input))
+	b.SetBytes(int64(len(dat)))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = r.Reset(bytes.NewBuffer(input))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = io.Copy(ioutil.Discard, r)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGunzipReadAll(b *testing.B) {
+	dat, _ := ioutil.ReadFile("testdata/test.json")
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dst := &bytes.Buffer{}
+	w, _ := NewWriterLevel(dst, 1)
+	_, err := w.Write(dat)
+	if err != nil {
+		b.Fatal(err)
+	}
+	w.Close()
+	input := dst.Bytes()
+	r, err := NewReader(bytes.NewBuffer(input))
+	b.SetBytes(int64(len(dat)))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = r.Reset(bytes.NewBuffer(input))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = ioutil.ReadAll(ioutil.NopCloser(r))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGunzipStdLib(b *testing.B) {
+	dat, _ := ioutil.ReadFile("testdata/test.json")
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dst := &bytes.Buffer{}
+	w, _ := NewWriterLevel(dst, 1)
+	_, err := w.Write(dat)
+	if err != nil {
+		b.Fatal(err)
+	}
+	w.Close()
+	input := dst.Bytes()
+	r, err := oldgz.NewReader(bytes.NewBuffer(input))
+	b.SetBytes(int64(len(dat)))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = r.Reset(bytes.NewBuffer(input))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = io.Copy(ioutil.Discard, r)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGunzipFlate(b *testing.B) {
+	dat, _ := ioutil.ReadFile("testdata/test.json")
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dat = append(dat, dat...)
+	dst := &bytes.Buffer{}
+	w, _ := NewWriterLevel(dst, 1)
+	_, err := w.Write(dat)
+	if err != nil {
+		b.Fatal(err)
+	}
+	w.Close()
+	input := dst.Bytes()
+	r, err := kpgzip.NewReader(bytes.NewBuffer(input))
+	b.SetBytes(int64(len(dat)))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		err = r.Reset(bytes.NewBuffer(input))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = io.Copy(ioutil.Discard, r)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/gzip.go
+++ b/gzip.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-
 	"sync"
 
 	"github.com/klauspost/compress/flate"


### PR DESCRIPTION
Add support for io.WriterTo interface to allow direct copying to output, and along with various optimizations in the decoder:

```
BenchmarkGunzipCopy-4                 30          48365416 ns/op         102.59 MB/s
BenchmarkGunzipReadAll-4              30          51174490 ns/op          96.96 MB/s
BenchmarkGunzipStdLib-4               20          57820485 ns/op          85.81 MB/s
BenchmarkGunzipFlate-4                30          48765666 ns/op         101.75 MB/s
```