### PR TITLE
Fix truncated gzip input

### DIFF
--- a/gunzip.go
+++ b/gunzip.go
@@ -388,7 +388,16 @@ func (z *Reader) doReadAhead() {
 			// Try to fill the buffer
 			n, err := io.ReadFull(decomp, buf)
 			if err == io.ErrUnexpectedEOF {
-				err = nil
+				if n > 0 {
+					err = nil
+				} else {
+					// If we got zero bytes, we need to establish if
+					// we reached end of stream or truncated stream.
+					_, err = decomp.Read([]byte{})
+					if err == io.EOF {
+						err = nil
+					}
+				}
 			}
 			if n < len(buf) {
 				buf = buf[0:n]


### PR DESCRIPTION
Since io.ErrUnexpectedEOF is returned on truncated results, we need to distinguish between truncated and end-of-stream reads.

Fixes https://github.com/klauspost/pgzip/issues/13