### PR TITLE
pgzip: Fix an occasional segfault/panic with pgzip

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -85,7 +85,7 @@ func (z *Writer) SetConcurrency(blockSize, blocks int) error {
 	z.blockSize = blockSize
 	z.results = make(chan result, blocks)
 	z.blocks = blocks
-	z.dstPool = sync.Pool{New: func() interface{} { return make([]byte, 0, blockSize+(blockSize)>>4) }}
+	z.dstPool.New = func() interface{} { return make([]byte, 0, blockSize+(blockSize)>>4) }
 	return nil
 }
 


### PR DESCRIPTION
This change fixes a occasional (5-10 out of 1000 test runs) segfault/panic on
sync.Pool struct access. Basically what happens there is that the original code
assigns a zero-value sync.Pool struct to the existing z.dstPool variable.
In general this kind of assignment is safe only if object is not used anymore /
in parallel by anything else. While is kind of true in a sense that none of the
goroutines are using it, in case of sync.Pool the garbage collector does
special management of the data with weak references and in right weather
conditions corrupts internal state (more precisely the sync.Pool.local might
become nil before reading it but after reading a nonzero sync.Pool.localSize;
leading to invalid memory reference in sync.Pool.Get() ).