### PR TITLE
Never return negative values from `Write`, as they can panic in `bufio`

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -405,11 +405,7 @@ func (z *Writer) Write(p []byte) (int, error) {
 		if len(z.currentBuffer) == z.blockSize {
 			z.compressCurrent(false)
 			if err := z.checkError(); err != nil {
-				numBytes := len(p) - len(q) - length
-				if numBytes < 0 {
-					numBytes = 0
-				}
-				return numBytes, err
+				return len(p) - len(q), err
 			}
 		}
 		z.size += length

--- a/gzip.go
+++ b/gzip.go
@@ -405,7 +405,11 @@ func (z *Writer) Write(p []byte) (int, error) {
 		if len(z.currentBuffer) == z.blockSize {
 			z.compressCurrent(false)
 			if err := z.checkError(); err != nil {
-				return len(p) - len(q) - length, err
+				numBytes := len(p) - len(q) - length
+				if numBytes < 0 {
+					numBytes = 0
+				}
+				return numBytes, err
 			}
 		}
 		z.size += length


### PR DESCRIPTION
Fixes #32.