### PR TITLE
RFC: Consume z.current prepared by Reader.Read in Reader.WriteTo

### DIFF
--- a/gunzip.go
+++ b/gunzip.go
@@ -502,6 +502,19 @@ func (z *Reader) Read(p []byte) (n int, err error) {
 
 func (z *Reader) WriteTo(w io.Writer) (n int64, err error) {
 	total := int64(0)
+	avail := z.current[z.roff:]
+	if len(avail) != 0 {
+		n, err := w.Write(avail)
+		if n != len(avail) {
+			return total, io.ErrShortWrite
+		}
+		total += int64(n)
+		if err != nil {
+			return total, err
+		}
+		z.blockPool <- z.current
+		z.current = nil
+	}
 	for {
 		if z.err != nil {
 			return total, z.err


### PR DESCRIPTION
... to fix missing data when WriteTo is called after Read.

---

This seems to fix https://github.com/containers/podman/issues/15944 , but I’m not familiar with the codebase and there might well be something important I’m missing.

I suppose I should also add at least _some_ tests; so I’m filing this early to maximize the opportunity for review / feedback.