### PR TITLE
fix: return currentBuffer and prevTail to dstPool in init to stop leak

### DIFF
--- a/gzip.go
+++ b/gzip.go
@@ -155,9 +155,19 @@ func (z *Writer) init(w io.Writer, level int) {
 	z.Extra = nil
 	z.ModTime = time.Time{}
 	z.wroteHeader = false
-	z.currentBuffer = nil
+	// Return any live buffer back to the pool before clearing it so
+	// repeated NewWriter/Close cycles via init(...) stop leaking one
+	// dstPool slot per iteration (#56). Same for prevTail, which init
+	// used to drop on the floor.
+	if z.currentBuffer != nil {
+		z.dstPool.Put(z.currentBuffer)
+		z.currentBuffer = nil
+	}
 	z.buf = [10]byte{}
-	z.prevTail = nil
+	if z.prevTail != nil {
+		z.dstPool.Put(z.prevTail)
+		z.prevTail = nil
+	}
 	z.size = 0
 	if z.dictFlatePool.New == nil {
 		z.dictFlatePool.New = func() any {

--- a/gzip.go
+++ b/gzip.go
@@ -155,10 +155,6 @@ func (z *Writer) init(w io.Writer, level int) {
 	z.Extra = nil
 	z.ModTime = time.Time{}
 	z.wroteHeader = false
-	// Return any live buffer back to the pool before clearing it so
-	// repeated NewWriter/Close cycles via init(...) stop leaking one
-	// dstPool slot per iteration (#56). Same for prevTail, which init
-	// used to drop on the floor.
 	if z.currentBuffer != nil {
 		z.dstPool.Put(z.currentBuffer)
 		z.currentBuffer = nil


### PR DESCRIPTION
## What

Fixes #56.

`Writer.init` unconditionally cleared `z.currentBuffer` and `z.prevTail` to `nil`. On a `Reset` / `Close` cycle that dropped a fully-allocated buffer (and an optional tail buffer) on the floor every iteration: both had just been fetched from `z.dstPool` on the preceding `Close` path (`compressCurrent` at gzip.go:272, `Close` calling `compressCurrent` with `flush=true`), so the pool never saw them again.

Long-running hot loops that reuse a single Writer with `Reset(buf); Write; Close; ...` grew allocations without bound as the sync.Pool hit-rate collapsed.

## Fix

Put both buffers back before zeroing them. The existing `// Put in .compressBlock` and `Put p / Put prevTail` call sites (lines 272, 397, 441, 458) show the pattern already in use for the other `Get` locations - this change just extends it to the init path so the pool is complete.

## Behaviour

- `NewWriter` → `init` on a fresh `*Writer`: both fields are zero-value `nil`, the new guards short-circuit, nothing changes.
- `Reset` → `SetConcurrency` → `init` after a `Close`: both fields hold live pool buffers, they are returned, and the pool stays healthy.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l`: clean
- `go vet ./...`: clean
- `go test -race -count=1 ./...`: pass (full suite, ~130s under -race)

Closes #56